### PR TITLE
Fix bug with add to cart where user can add more than limit

### DIFF
--- a/client/src/components/AddToCartButton.jsx
+++ b/client/src/components/AddToCartButton.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 const AddToCartButton = ({ productLimit, handleCartAddClick, cartQuantity }) => {
-  const limitExceeded = cartQuantity === productLimit;
+  const limitExceeded = cartQuantity >= productLimit;
   const [clicked, setClicked] = useState(false);
   const onClick = () => {
     setClicked(true);

--- a/client/src/components/ProductOverview.jsx
+++ b/client/src/components/ProductOverview.jsx
@@ -94,6 +94,7 @@ const Container = styled.div`
   @media screen and (max-width: 352.797px) {
     flex: 0 0 30%;
   };
+  margin: auto;
 `;
 
 const BadgeWrapper = styled.div`


### PR DESCRIPTION
Hello, 

This is my PR for my bug fix.

Changes:
- Limit exceeded renders if adds using input twice. For example, if limit is 4, and user inputs 2 and then inputs 3, cart will render as limit exceeded
- Added margin: auto to overall container